### PR TITLE
fix: adaptar botones de descarga a pantalla móvil

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1048,8 +1048,8 @@
       .privacy-shield svg { width: 70px; height: 70px; }
 
       /* Download */
-      .download-buttons { flex-direction: column; align-items: center; }
-      .download-btn { width: 100%; max-width: 280px; }
+      .download-buttons { flex-direction: column; align-items: center; width: 100%; }
+      .download-btn { width: 100%; max-width: 320px; min-width: unset; padding: 18px 28px; }
 
       /* Footer */
       .footer-links { flex-wrap: wrap; justify-content: center; }
@@ -1060,6 +1060,9 @@
       .section-title { font-size: 1.5rem; }
       .hero-title { font-size: 2rem; }
       .provider-badge { min-width: 100px; padding: 12px 16px; }
+      /* Download botones en móvil pequeño */
+      .download-btn { max-width: 100%; padding: 16px 20px; }
+      .download-btn-main { font-size: 0.95rem; }
     }
 
     /* =============================================


### PR DESCRIPTION
En pantallas pequeñas los botones de descarga quedaban en fila horizontal
y se salían de los bordes laterales. Se corrigen las media queries:

- @media ≤767px: añade width:100% al contenedor, elimina min-width del
  botón, aumenta max-width a 320px y reduce padding
- @media ≤480px: expande el botón a max-width:100% con padding más
  compacto y reduce el font-size del texto principal

https://claude.ai/code/session_01YA6E87AaB9126rQkieVa5E