### PR TITLE
feat(wiki): make wiki URL configurable via VITE_WIKI_URL env

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -7,6 +7,8 @@ import {
 import { aiQueueService } from '../../services/ai/aiQueueService';
 import BugReportButton from '../BugReportButton/BugReportButton';
 
+const WIKI_URL = import.meta.env.VITE_WIKI_URL || 'https://rgarciade.github.io/airecorder/vp/';
+
 const Sidebar = ({ currentView, onViewChange, queueCount = 0, diarizationEnabled = false }) => {
   const { t } = useTranslation();
   const [aiQueueCount, setAiQueueCount] = useState(0);
@@ -65,7 +67,7 @@ const Sidebar = ({ currentView, onViewChange, queueCount = 0, diarizationEnabled
           className={styles.navItem}
           onClick={() => {
             if (window.electronAPI && window.electronAPI.openExternal) {
-              window.electronAPI.openExternal('https://rgarciade.github.io/airecorder/vp/');
+              window.electronAPI.openExternal(WIKI_URL);
             }
           }}
           title={t('sidebar.wiki')}

--- a/src/pages/Onboarding/LocalAiInfoStep.jsx
+++ b/src/pages/Onboarding/LocalAiInfoStep.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { FaRobot, FaServer, FaExternalLinkAlt, FaBrain, FaSearch, FaArrowRight, FaShieldAlt } from 'react-icons/fa';
 import OnboardingFooter from './OnboardingFooter';
 
+const WIKI_BASE_URL = import.meta.env.VITE_WIKI_URL || 'https://rgarciade.github.io/airecorder/vp/';
+
 const LocalAiInfoStep = ({ t, onNext, onBack, StepProgressComponent }) => {
   const handleOpenDocs = (e) => {
     e.preventDefault();
-    const url = 'https://rgarciade.github.io/airecorder/vp/guide/local-ai';
+    const url = `${WIKI_BASE_URL}guide/local-ai`;
     if (window.electronAPI && window.electronAPI.openExternal) {
       window.electronAPI.openExternal(url);
     } else {

--- a/src/pages/Settings/components/AgentsTab/CloudProvidersSection.jsx
+++ b/src/pages/Settings/components/AgentsTab/CloudProvidersSection.jsx
@@ -5,7 +5,7 @@ import {
 import styles from '../../Settings.module.css';
 import { useSettings } from '../../SettingsContext';
 
-const WIKI_URL = 'https://rgarciade.github.io/airecorder/vp/';
+const WIKI_URL = import.meta.env.VITE_WIKI_URL || 'https://rgarciade.github.io/airecorder/vp/';
 
 export default function CloudProvidersSection() {
   const {

--- a/src/pages/Settings/components/AgentsTab/LocalProvidersSection.jsx
+++ b/src/pages/Settings/components/AgentsTab/LocalProvidersSection.jsx
@@ -6,7 +6,7 @@ import styles from '../../Settings.module.css';
 import InfoTooltip from '../../../../components/InfoTooltip/InfoTooltip';
 import { useSettings } from '../../SettingsContext';
 
-const WIKI_URL = 'https://rgarciade.github.io/airecorder/vp/';
+const WIKI_URL = import.meta.env.VITE_WIKI_URL || 'https://rgarciade.github.io/airecorder/vp/';
 
 export default function LocalProvidersSection() {
   const {


### PR DESCRIPTION
## Resumen

Centraliza la URL de la wiki detrás de la variable de entorno `VITE_WIKI_URL`, manteniendo la URL de GitHub Pages como fallback. Esto permite probar la app contra el dev server local de VitePress (`npm run docs:dev` en `http://localhost:3001/`) sin tocar el código.

## Cambios

- `src/components/Sidebar/Sidebar.jsx` — botón Wiki de la sidebar usa la constante `WIKI_URL`
- `src/pages/Settings/components/AgentsTab/LocalProvidersSection.jsx` — link "Ver en Wiki"
- `src/pages/Settings/components/AgentsTab/CloudProvidersSection.jsx` — link "Ver en Wiki"
- `src/pages/Onboarding/LocalAiInfoStep.jsx` — CTA de docs en el onboarding

Todos los lugares leen `import.meta.env.VITE_WIKI_URL || 'https://rgarciade.github.io/airecorder/vp/'`. Sin .env, la app sigue apuntando a producción.

## Cómo probar local

1. Levantar la wiki:
```bash
npm run docs:dev
# sirve en http://localhost:3001/
```

2. Levantar la app con la URL apuntando a local:
```bash
VITE_WIKI_URL=http://localhost:3001/ npm run dev
```

3. Click en el botón **Wiki** de la sidebar o en **Ver en Wiki** en Settings → Agentes IA. Debe abrir `localhost:3001` en el navegador externo.

## Nota sobre el deploy

Verifiqué que `https://rgarciade.github.io/airecorder/vp/` devuelve **404** hoy. Eso es independiente de este PR (es un problema del deploy de GitHub Pages). Este cambio igual aporta valor: una vez arreglado el deploy, la misma variable de entorno permite validar cambios de la wiki antes de publicar.

Closes #42