### PR TITLE
feat(seo): agregar canonical, hreflang, OG/Twitter y sitemap dinámico en web y wiki

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,73 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { defineConfig } from 'vitepress'
+
+// ============================================================
+// SEO helpers — shared by transformPageData (per-page canonical /
+// hreflang / OG tags) and buildEnd (sitemap.xml generation), so the
+// es<->en URL pairing logic lives in exactly one place.
+// ============================================================
+
+const SITE_ORIGIN = 'https://rgarciade.github.io/airecorder'
+const WIKI_BASE = `${SITE_ORIGIN}/vp/`
+const SITE_NAME = 'AIRecorder'
+const OG_IMAGE = `${SITE_ORIGIN}/icon.png`
+
+// Mirrors VitePress's own internal route-normalization regex (see
+// INDEX_OR_EXT_RE in vitepress/dist/node/chunk-*.js): strips a trailing
+// "index.md" (collapsing to the parent directory) or a bare ".md"
+// extension, matching exactly how `cleanUrls: true` resolves real URLs.
+// e.g. "index.md" -> "", "guide/index.md" -> "guide/", "guide/faq.md" -> "guide/faq"
+const INDEX_OR_EXT_RE = /(?:(^|\/)index)?\.md$/
+
+/**
+ * Given a page's `relativePath` (as found on `pageData.relativePath` in
+ * transformPageData, or as an entry of `siteConfig.pages` in buildEnd —
+ * both share the exact same "path/relative/to/srcDir.md" format), resolve
+ * its locale, its clean route, and the canonical + es/en sibling URLs.
+ */
+function resolvePageMeta(relativePath: string) {
+  const route = relativePath.replace(INDEX_OR_EXT_RE, '$1')
+  const locale: 'es' | 'en' = route === 'en' || route.startsWith('en/') ? 'en' : 'es'
+  const bareRoute = locale === 'en' ? route.slice(3) : route // strips "en/"
+  const es = `${WIKI_BASE}${bareRoute}`
+  const en = `${WIKI_BASE}en/${bareRoute}`
+  const canonical = locale === 'en' ? en : es
+  return { route, bareRoute, locale, canonical, es, en }
+}
+
+/** Priority/changefreq convention carried over from the previous hand-written sitemap. */
+function computeSeoWeight(bareRoute: string, locale: 'es' | 'en') {
+  let priority: number
+  let changefreq: 'weekly' | 'monthly'
+
+  if (bareRoute === '') {
+    priority = 0.9
+    changefreq = 'weekly'
+  } else if (bareRoute === 'guide/') {
+    priority = 0.8
+    changefreq = 'weekly'
+  } else if (bareRoute === 'reference/') {
+    priority = 0.6
+    changefreq = 'monthly'
+  } else if (bareRoute.startsWith('guide/')) {
+    priority = bareRoute === 'guide/local-ai' ? 0.8 : 0.7
+    changefreq = 'weekly'
+  } else if (bareRoute.startsWith('reference/')) {
+    priority = 0.5
+    changefreq = 'monthly'
+  } else {
+    priority = 0.5
+    changefreq = 'monthly'
+  }
+
+  // English pages mirror their Spanish counterpart one tier down, same
+  // convention the previous manual sitemap already used (e.g. es guide
+  // subpages 0.7 -> en guide subpages 0.6).
+  if (locale === 'en') priority = Math.round((priority - 0.1) * 10) / 10
+
+  return { priority: priority.toFixed(1), changefreq }
+}
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -137,5 +206,96 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', type: 'image/png', href: '/airecorder/icon.png' }]
-  ]
+  ],
+
+  // FIX 1: inject canonical + hreflang + OG/Twitter tags into every page's
+  // frontmatter.head (VitePress merges this array into the real <head>).
+  transformPageData(pageData) {
+    // Skip the virtual "not found" page — it has no real route to canonicalize.
+    if (pageData.isNotFound || pageData.relativePath === '404.md') return
+
+    const { locale, canonical, es, en } = resolvePageMeta(pageData.relativePath)
+    const frontmatter = pageData.frontmatter
+
+    const title = frontmatter.title || pageData.title || SITE_NAME
+    const ogTitle = title === SITE_NAME ? SITE_NAME : `${title} | ${SITE_NAME}`
+    const description =
+      frontmatter.description ||
+      pageData.description ||
+      (locale === 'en' ? 'AIRecorder documentation' : 'Documentación de AIRecorder')
+    const ogLocale = locale === 'en' ? 'en_US' : 'es_ES'
+
+    frontmatter.head ??= []
+    frontmatter.head.push(
+      ['link', { rel: 'canonical', href: canonical }],
+      // Self-referencing entry is mandatory in hreflang sets, not just the sibling.
+      ['link', { rel: 'alternate', hreflang: 'es', href: es }],
+      ['link', { rel: 'alternate', hreflang: 'en', href: en }],
+      ['link', { rel: 'alternate', hreflang: 'x-default', href: es }],
+      ['meta', { property: 'og:title', content: ogTitle }],
+      ['meta', { property: 'og:description', content: description }],
+      ['meta', { property: 'og:url', content: canonical }],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:image', content: OG_IMAGE }],
+      ['meta', { property: 'og:locale', content: ogLocale }],
+      ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+      ['meta', { name: 'twitter:title', content: ogTitle }],
+      ['meta', { name: 'twitter:description', content: description }],
+      ['meta', { name: 'twitter:image', content: OG_IMAGE }]
+    )
+  },
+
+  // FIX 2: regenerate docs/sitemap.xml (covers the whole site, not just the
+  // VitePress wiki) from the actual page list on every build — no manual drift.
+  buildEnd(siteConfig) {
+    const today = new Date().toISOString().slice(0, 10)
+
+    const wikiPages = siteConfig.pages
+      .map((relativePath) => {
+        const meta = resolvePageMeta(relativePath)
+        const { priority, changefreq } = computeSeoWeight(meta.bareRoute, meta.locale)
+        return { ...meta, priority, changefreq }
+      })
+      .sort((a, b) => a.canonical.localeCompare(b.canonical))
+
+    const staticEntries = [
+      { loc: `${SITE_ORIGIN}/`, changefreq: 'weekly', priority: '1.0' },
+      { loc: `${SITE_ORIGIN}/changelog.html`, changefreq: 'monthly', priority: '0.6' }
+    ]
+
+    const lines: string[] = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    ]
+
+    for (const entry of staticEntries) {
+      lines.push(
+        '  <url>',
+        `    <loc>${entry.loc}</loc>`,
+        `    <changefreq>${entry.changefreq}</changefreq>`,
+        `    <priority>${entry.priority}</priority>`,
+        '  </url>'
+      )
+    }
+
+    for (const page of wikiPages) {
+      lines.push(
+        '  <url>',
+        `    <loc>${page.canonical}</loc>`,
+        `    <lastmod>${today}</lastmod>`,
+        `    <changefreq>${page.changefreq}</changefreq>`,
+        `    <priority>${page.priority}</priority>`,
+        `    <xhtml:link rel="alternate" hreflang="es" href="${page.es}"/>`,
+        `    <xhtml:link rel="alternate" hreflang="en" href="${page.en}"/>`,
+        `    <xhtml:link rel="alternate" hreflang="x-default" href="${page.es}"/>`,
+        '  </url>'
+      )
+    }
+
+    lines.push('</urlset>', '')
+
+    // outDir is docs/vp — sitemap.xml must live at docs/sitemap.xml (site root)
+    const sitemapPath = path.resolve(siteConfig.outDir, '../sitemap.xml')
+    fs.writeFileSync(sitemapPath, lines.join('\n'), 'utf-8')
+  }
 })

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Página no encontrada | AIRecorder</title>
+  <meta name="description" content="La página que buscás no existe o fue movida. Volvé al inicio o consultá la documentación de AIRecorder.">
+  <meta name="theme-color" content="#3994EF">
+  <link rel="icon" type="image/png" href="/airecorder/icon.png">
+
+  <!--
+    NOTA: GitHub Pages sirve este archivo para CUALQUIER ruta no encontrada
+    bajo /airecorder/*, pero la URL en la barra del navegador sigue siendo
+    la ruta original (no cambia a /404.html). Por eso TODOS los recursos y
+    enlaces de esta página usan rutas absolutas (/airecorder/...) en lugar
+    de relativas: una ruta relativa como "icon.png" se resolvería contra la
+    ruta profunda que dio 404, no contra la raíz del sitio, y rompería.
+  -->
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+
+  <style>
+    :root {
+      --color-primary: #3994EF;
+      --color-primary-hover: #2563EB;
+      --color-primary-light: #EFF6FF;
+      --color-bg: #F8F9FB;
+      --color-white: #FFFFFF;
+      --color-text: #111827;
+      --color-text-secondary: #374151;
+      --color-text-muted: #9CA3AF;
+      --color-border: #E5E7EB;
+      --font-family: 'Plus Jakarta Sans', 'Noto Sans', sans-serif;
+      --radius-md: 12px;
+      --radius-xl: 24px;
+      --radius-pill: 50px;
+      --shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+      --shadow-button: 0 4px 15px rgba(57, 148, 239, 0.35);
+      --shadow-icon: 0 20px 40px rgba(0, 0, 0, 0.18);
+      --transition: all 0.25s ease;
+    }
+
+    * , *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html {
+      font-size: 16px;
+      color-scheme: light;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-family);
+      background-color: var(--color-bg);
+      background-image:
+        radial-gradient(ellipse 80% 60% at 50% -10%, rgba(57, 148, 239, 0.08) 0%, transparent 70%),
+        radial-gradient(ellipse 60% 40% at 80% 80%, rgba(147, 51, 234, 0.04) 0%, transparent 60%);
+      color: var(--color-text);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      padding: 24px;
+    }
+
+    a { text-decoration: none; }
+
+    .wrap {
+      max-width: 480px;
+      text-align: center;
+    }
+
+    .icon {
+      width: 96px;
+      height: 96px;
+      border-radius: var(--radius-xl);
+      box-shadow: var(--shadow-icon);
+      margin: 0 auto 32px;
+      background: url('/airecorder/icon.png') 50% 49% / 164% no-repeat;
+    }
+
+    .code {
+      font-size: 4rem;
+      font-weight: 900;
+      letter-spacing: -0.02em;
+      line-height: 1;
+      background: linear-gradient(135deg, var(--color-primary) 0%, #9333EA 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 16px;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 800;
+      color: var(--color-text);
+      margin-bottom: 12px;
+    }
+
+    p {
+      font-size: 1rem;
+      color: var(--color-text-secondary);
+      margin-bottom: 32px;
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 14px 28px;
+      border-radius: var(--radius-pill);
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: var(--transition);
+      white-space: nowrap;
+    }
+
+    .btn-primary {
+      background: var(--color-primary);
+      color: var(--color-white);
+      box-shadow: var(--shadow-button);
+    }
+
+    .btn-primary:hover {
+      background: var(--color-primary-hover);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(57, 148, 239, 0.45);
+    }
+
+    .btn-secondary {
+      background: var(--color-white);
+      color: var(--color-text-secondary);
+      border: 1px solid var(--color-border);
+      box-shadow: var(--shadow-card);
+    }
+
+    .btn-secondary:hover {
+      background: var(--color-bg);
+      color: var(--color-text);
+      transform: translateY(-1px);
+    }
+
+    @media (max-width: 480px) {
+      .actions { flex-direction: column; width: 100%; }
+      .actions .btn { width: 100%; justify-content: center; }
+      .code { font-size: 3rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="icon" role="img" aria-label="AIRecorder"></div>
+    <p class="code">404</p>
+    <h1>Página no encontrada</h1>
+    <p>La página que buscás no existe o fue movida a otra ubicación.</p>
+    <div class="actions">
+      <a href="/airecorder/" class="btn btn-primary">Ir al inicio</a>
+      <a href="/airecorder/vp/" class="btn btn-secondary">Ver la documentación</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AIRecorder — Graba y Transcribe Reuniones con IA Local</title>
-  <meta name="description" content="Aplicación macOS que graba audio, transcribe con Whisper y analiza reuniones con IA. 100% local y privado. Compatible con Ollama, LM Studio, Gemini y DeepSeek.">
+  <meta name="description" content="Aplicación macOS que graba, transcribe con Whisper y analiza tus reuniones con IA local. 100% privado. Compatible con Ollama, LM Studio, Gemini y DeepSeek.">
   <meta name="keywords" content="grabadora reuniones, transcripción automática, IA local, Whisper, Ollama, LM Studio, macOS, privacidad, diarización, análisis reuniones">
   <meta name="author" content="Raul Garcia">
   <meta name="robots" content="index, follow">
@@ -14,7 +14,7 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="AIRecorder — Graba y Transcribe Reuniones con IA Local">
-  <meta property="og:description" content="Aplicación macOS que graba audio, transcribe con Whisper y analiza reuniones con IA. 100% local y privado. Compatible con Ollama, LM Studio, Gemini y DeepSeek.">
+  <meta property="og:description" content="Aplicación macOS que graba, transcribe con Whisper y analiza tus reuniones con IA local. 100% privado. Compatible con Ollama, LM Studio, Gemini y DeepSeek.">
   <meta property="og:image" content="https://rgarciade.github.io/airecorder/icon.png">
   <meta property="og:url" content="https://rgarciade.github.io/airecorder/">
   <meta property="og:type" content="website">
@@ -24,7 +24,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="AIRecorder — Graba y Transcribe Reuniones con IA Local">
-  <meta name="twitter:description" content="Aplicación macOS que graba audio, transcribe con Whisper y analiza reuniones con IA. 100% local y privado.">
+  <meta name="twitter:description" content="Aplicación macOS que graba, transcribe con Whisper y analiza tus reuniones con IA local. 100% privado. Compatible con Ollama, LM Studio, Gemini y DeepSeek.">
   <meta name="twitter:image" content="https://rgarciade.github.io/airecorder/icon.png">
 
   <!-- Structured Data -->

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,130 +1,373 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://rgarciade.github.io/airecorder/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://rgarciade.github.io/airecorder/docs.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/wiki.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://rgarciade.github.io/airecorder/changelog.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
-  <!-- VitePress Docs -->
   <url>
     <loc>https://rgarciade.github.io/airecorder/vp/</loc>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/"/>
   </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/recording</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/transcription</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/chat</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/export</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/projects</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/speakers</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/local-ai</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/guide/faq</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/reference/</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/reference/architecture</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/reference/rag</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/reference/diarization</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/reference/prompts</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/reference/contributing</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <!-- English locale -->
   <url>
     <loc>https://rgarciade.github.io/airecorder/vp/en/</loc>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/"/>
   </url>
   <url>
     <loc>https://rgarciade.github.io/airecorder/vp/en/guide/</loc>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/"/>
   </url>
   <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/recording</loc>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/chat</loc>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/chat"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/chat"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/chat"/>
   </url>
   <url>
-    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/local-ai</loc>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/cloud-ai</loc>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/cloud-ai"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/cloud-ai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/cloud-ai"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/custom-ai</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/custom-ai"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/custom-ai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/custom-ai"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/export</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/export"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/export"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/export"/>
   </url>
   <url>
     <loc>https://rgarciade.github.io/airecorder/vp/en/guide/faq</loc>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/faq"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/faq"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/faq"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/local-ai</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/local-ai"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/local-ai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/local-ai"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/projects</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/projects"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/projects"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/projects"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/recording</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/recording"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/recording"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/recording"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/schema</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/schema"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/schema"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/schema"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/settings</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/settings"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/settings"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/settings"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/speakers</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/speakers"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/speakers"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/speakers"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/guide/transcription</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/transcription"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/transcription"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/transcription"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/reference/</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/reference/architecture</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/architecture"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/architecture"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/architecture"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/reference/contributing</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/contributing"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/contributing"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/contributing"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/reference/diarization</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/diarization"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/diarization"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/diarization"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/reference/prompts</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/prompts"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/prompts"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/prompts"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/en/reference/rag</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/rag"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/rag"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/rag"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/chat</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/chat"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/chat"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/chat"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/cloud-ai</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/cloud-ai"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/cloud-ai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/cloud-ai"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/custom-ai</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/custom-ai"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/custom-ai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/custom-ai"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/export</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/export"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/export"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/export"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/faq</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/faq"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/faq"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/faq"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/local-ai</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/local-ai"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/local-ai"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/local-ai"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/projects</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/projects"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/projects"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/projects"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/recording</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/recording"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/recording"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/recording"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/schema</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/schema"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/schema"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/schema"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/settings</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/settings"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/settings"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/settings"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/speakers</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/speakers"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/speakers"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/speakers"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/guide/transcription</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/guide/transcription"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/guide/transcription"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/guide/transcription"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/reference/</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/reference/architecture</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/architecture"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/architecture"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/architecture"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/reference/contributing</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/contributing"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/contributing"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/contributing"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/reference/diarization</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/diarization"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/diarization"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/diarization"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/reference/prompts</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/prompts"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/prompts"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/prompts"/>
+  </url>
+  <url>
+    <loc>https://rgarciade.github.io/airecorder/vp/reference/rag</loc>
+    <lastmod>2026-07-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="es" href="https://rgarciade.github.io/airecorder/vp/reference/rag"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rgarciade.github.io/airecorder/vp/en/reference/rag"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rgarciade.github.io/airecorder/vp/reference/rag"/>
   </url>
 </urlset>

--- a/docs/vp-src/en/index.md
+++ b/docs/vp-src/en/index.md
@@ -1,0 +1,36 @@
+---
+layout: home
+
+title: AIRecorder
+titleTemplate: Documentation
+description: "Official AIRecorder documentation: record, transcribe, and analyze your meetings with local, private AI."
+
+hero:
+  name: AIRecorder
+  text: Documentation
+  tagline: Record, transcribe, and analyze audio with local AI.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /en/guide/
+    - theme: alt
+      text: Technical Reference
+      link: /en/reference/
+
+features:
+  - title: Audio Recording
+    details: Record microphone and system audio in high quality.
+    link: /en/guide/recording
+
+  - title: AI Transcription
+    details: Convert audio to text using local or cloud Whisper.
+    link: /en/guide/transcription
+
+  - title: Chat with Your Audio
+    details: Ask questions about your recordings using conversational AI.
+    link: /en/guide/chat
+
+  - title: Total Privacy
+    details: All data is processed and stored locally on your device.
+    link: /en/guide/faq
+---

--- a/docs/vp-src/index.md
+++ b/docs/vp-src/index.md
@@ -3,6 +3,7 @@ layout: home
 
 title: AIRecorder
 titleTemplate: Documentación
+description: "Documentación oficial de AIRecorder: graba, transcribe y analiza tus reuniones con IA local y privada."
 
 hero:
   name: AIRecorder


### PR DESCRIPTION
Closes #89

## Resumen
- `docs/.vitepress/config.ts`: `transformPageData` inyecta canonical + hreflang recíproco (es/en/x-default, self-referencing) + OG/Twitter en las 26 páginas del wiki, usando el title/description que ya tenía el frontmatter. `buildEnd` regenera `docs/sitemap.xml` completo (antes desactualizado a mano) en cada build, sin dependencias nuevas.
- `docs/vp-src/en/index.md`: no existía — la home en inglés daba 404 real en el sitio (`/vp/en/`). Sin esto el hreflang "en" de toda la wiki apuntaba a una página muerta.
- `docs/index.html`: description/og/twitter recortados de 160 a 157 caracteres y unificados; `docs/404.html` propio para GitHub Pages (rutas absolutas, sin `noindex`).

Auditoría completa (confirmada contra el sitio live con curl, no solo build local): cero canonical/hreflang/OG en las 26 páginas del wiki, sitemap incompleto sin lastmod/hreflang e indexando por error los stubs de redirect `docs.html`/`wiki.html`.

## Test plan
- [x] `npm run docs:build` limpio, sin errores
- [x] `docs/sitemap.xml` generado: 42 URLs, XML válido, sin duplicados, sin docs.html/wiki.html, lastmod + hreflang recíproco en cada entrada
- [x] Verificado en HTML generado (es y en `guide/faq.html`, home es/en): canonical sin `.html` (cleanUrls), hreflang self-ref + recíproco, OG/Twitter completos y con locale correcto
- [x] `docs/404.html` válido, sin `noindex`